### PR TITLE
Set short time Format in Audit log

### DIFF
--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -123,7 +123,7 @@ const (
 	ExistingContainerHostEnv = MinikubeExistingPrefix + "CONTAINER_HOST"
 
 	// TimeFormat is the format that should be used when outputting time
-	TimeFormat = time.RFC1123
+	TimeFormat = time.RFC822
 	// MaxResources is the value that can be passed into the memory and cpus flags to specify to use maximum resources
 	MaxResources = "max"
 


### PR DESCRIPTION
changed time Format to time.RFC822 from time.RFC1123,
Now it looks little shorter than before in auidt logs